### PR TITLE
fix compile on recent glibc: SIGSTKSZ not always a constant expression

### DIFF
--- a/include/eosio/vm/execution_context.hpp
+++ b/include/eosio/vm/execution_context.hpp
@@ -286,7 +286,7 @@ namespace eosio { namespace vm {
                std::reverse(args_raw + 0, args_raw + sizeof...(Args));
                result = call_host_function(args_raw, func_index);
             } else {
-               constexpr std::size_t stack_cutoff = std::max(252144, SIGSTKSZ);
+               const std::size_t stack_cutoff = std::max<std::size_t>(252144, SIGSTKSZ);
                std::size_t maximum_stack_usage =
                   (_mod.maximum_stack + 2 /*frame ptr + return ptr*/) * (constants::max_call_depth + 1) +
                  sizeof...(Args) + 4 /* scratch space */;


### PR DESCRIPTION
On recent glibc versions SIGSTKSZ is not always a constant expression but rather a function call. Change the `constexpr` to `const`. Also, remove the template parameter deduction so it'll work in all cases