### PR TITLE
tweak usage of invoke_with_signal_handler() for gcc12

### DIFF
--- a/include/eosio/vm/execution_context.hpp
+++ b/include/eosio/vm/execution_context.hpp
@@ -312,11 +312,11 @@ namespace eosio { namespace vm {
 
                   vm::invoke_with_signal_handler([&]() {
                      result = execute<sizeof...(Args)>(args_raw, fn, this, base_type::linear_memory(), stack);
-                  }, handle_signal);
+                  }, &handle_signal);
                } else {
                   vm::invoke_with_signal_handler([&]() {
                      result = execute<sizeof...(Args)>(args_raw, fn, this, base_type::linear_memory(), stack);
-                  }, handle_signal);
+                  }, &handle_signal);
                }
             }
          } catch(wasm_exit_exception&) {


### PR DESCRIPTION
Needed to make this change to get eos-vm to compile with GCC 12.1-rc1 otherwise it would complain
```
invalid initialization of reference of type ‘void (&&)(int)’ from expression of type ‘void(int)’
```

mmmm :thinking: mmmmmmmm :thinking: :thinking: honestly not sure I quite follow its reasoning here.